### PR TITLE
Add workflow to assign PR creator

### DIFF
--- a/.github/workflows/assign-creator.yml
+++ b/.github/workflows/assign-creator.yml
@@ -1,0 +1,25 @@
+name: Assign PR Creator
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Assign PR Creator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const actor = process.env.GITHUB_ACTOR;
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [actor]
+            });
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a workflow file that automatically assigns the creator of the pull request as an assignee. This will help ensure that the creator remains involved in the review and resolution process.